### PR TITLE
Use Que::Adapters::Base in test adapter

### DIFF
--- a/lib/que/testing/adapter.rb
+++ b/lib/que/testing/adapter.rb
@@ -3,7 +3,7 @@ module Que
     class JobParams < Struct.new(:queue, :priority, :run_at, :job_class, :args)
     end
 
-    class Adapter
+    class Adapter < Que::Adapters::Base
       def checkout(&block)
       end
 


### PR DESCRIPTION
 This gets default (no-op) implementations of required methods.
