### PR TITLE
Add a "gem update bundler" before install step to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - gem update bundler
 language: ruby
 rvm:
   - 1.9.3


### PR DESCRIPTION
The version of bundler used in the Travis CI builds is 1.7.6, which is from Nov 2014 and causes issues, such as:

```
NoMethodError: undefined method `spec' for nil:NilClass
An error occurred while installing que-testing (0.1.1), and Bundler cannot
```
